### PR TITLE
ensure in right folder and use psql as check if postgresql is up

### DIFF
--- a/scripts/first_run.sh
+++ b/scripts/first_run.sh
@@ -4,9 +4,11 @@ PASS=${POSTGRES_PASSWORD:-$(pwgen -s -1 16)}
 DB=${POSTGRES_DBNAME:-}
 EXTENSIONS=${POSTGRES_EXTENSIONS:-}
 
+cd /var/lib/postgresql
 # Start PostgreSQL service
 sudo -u postgres /usr/lib/postgresql/9.3/bin/postgres -D /data &
-while ! nc -vz localhost 5432; do sleep 1; done
+
+while ! sudo -u postgres psql -q -c "select true;"; do sleep 1; done
 
 # Create user
 echo "Creating user: \"$USER\"..."

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd /var/lib/postgresql
+
 # Initialize data directory
 DATA_DIR=/data
 if [ ! -f $DATA_DIR/postgresql.conf ]; then


### PR DESCRIPTION
I was running into issues of `could not change directory to "/root": Permission denied` so I cd into correct folder. I don't believe this is root of my problem.

Fix was root of problem I believe is the nc checked port was up but postgresql wasn't up. I ran into this problem on a slower openstack which cause user and database not to be created. Using psql ensure that  postgres was up and I was able to create user.
